### PR TITLE
Manually run query_posts if Cortex is booted

### DIFF
--- a/src/Cortex.php
+++ b/src/Cortex.php
@@ -65,6 +65,10 @@ class Cortex
                     $do = $instance->doBoot($wp, $do, $request);
                     unset($instance);
 
+					if ( ! $do ) {
+						$wp->query_posts();
+					}
+
                     return $do;
                 } catch (\Exception $e) {
                     if (defined('WP_DEBUG') && WP_DEBUG) {


### PR DESCRIPTION
As it is no longer run in WP::main() from WordPress 6.0

Resolves #31 