### PR TITLE
Fixed get_post() call inside template (see #35)

### DIFF
--- a/src/Cortex.php
+++ b/src/Cortex.php
@@ -67,7 +67,6 @@ class Cortex
 
                     if ( ! $do ) {
                         $wp->query_posts();
-                        $wp->handle_404();
                         $wp->register_globals();
                     }
 

--- a/src/Cortex.php
+++ b/src/Cortex.php
@@ -66,8 +66,12 @@ class Cortex
                     unset($instance);
 
                     if ( ! $do ) {
-                        $wp->query_posts();
-                        $wp->register_globals();
+                        global $wp_version;
+
+                        if ( $wp_version && version_compare( $wp_version, '6', '>=' ) ) {
+                            $wp->query_posts();
+                            $wp->register_globals();
+                        }
                     }
 
                     return $do;

--- a/src/Cortex.php
+++ b/src/Cortex.php
@@ -65,11 +65,11 @@ class Cortex
                     $do = $instance->doBoot($wp, $do, $request);
                     unset($instance);
 
-					if ( ! $do ) {
-						$wp->query_posts();
+                    if ( ! $do ) {
+                        $wp->query_posts();
                         $wp->handle_404();
                         $wp->register_globals();
-					}
+                    }
 
                     return $do;
                 } catch (\Exception $e) {

--- a/src/Cortex.php
+++ b/src/Cortex.php
@@ -67,6 +67,8 @@ class Cortex
 
 					if ( ! $do ) {
 						$wp->query_posts();
+                        $wp->handle_404();
+                        $wp->register_globals();
 					}
 
                     return $do;


### PR DESCRIPTION
Added `handle_404()` and `register_globals` if Cortex is booted, like `query_posts` was added in #32 

Fixed #35 