### PR TITLE
Correct trim function first parameter

### DIFF
--- a/src/Cortex/Uri/WordPressUri.php
+++ b/src/Cortex/Uri/WordPressUri.php
@@ -70,7 +70,8 @@ final class WordPressUri implements UriInterface
          * `example.com/subfolder` we need to strip down `/subfolder` from path and build a path
          * for route matching that is relative to home url.
          */
-        $homePath = trim(parse_url(home_url(), PHP_URL_PATH), '/');
+        $parseHomeUrl = parse_url(home_url(), PHP_URL_PATH) ?? '';
+        $homePath = trim($parseHomeUrl, '/');
         $path = trim($this->uri->getPath(), '/');
         if ($homePath && strpos($path, $homePath) === 0) {
             $path = trim(substr($path, strlen($homePath)), '/');


### PR DESCRIPTION
This PR fixes PHP 8 deprecated notices for `trim()` function.