### PR TITLE
PHP 8.1 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require":           {
         "php":              ">=5.5",
         "nikic/fast-route": "~0.7.0",
-        "psr/http-message": "*"
+        "psr/http-message": "<1.1"
     },
     "require-dev":       {
         "phpunit/phpunit": "4.8.*",

--- a/src/Cortex/Group/Group.php
+++ b/src/Cortex/Group/Group.php
@@ -62,6 +62,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->route->offsetExists($offset);
@@ -70,6 +71,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->route->offsetGet($offset);
@@ -78,6 +80,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->route->offsetSet($offset, $value);
@@ -86,6 +89,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->route->offsetUnset($offset);

--- a/src/Cortex/Route/DerivativeRouteTrait.php
+++ b/src/Cortex/Route/DerivativeRouteTrait.php
@@ -40,6 +40,7 @@ trait DerivativeRouteTrait
      * @param  string $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->route->offsetExists($offset);
@@ -50,6 +51,7 @@ trait DerivativeRouteTrait
      * @param  string $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->route->offsetGet($offset);
@@ -60,6 +62,7 @@ trait DerivativeRouteTrait
      * @param string $offset
      * @param mixed  $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->route->offsetSet($offset, $value);
@@ -69,6 +72,7 @@ trait DerivativeRouteTrait
      * @see RouteInterface::offsetUnset()
      * @param string $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->route->offsetUnset($offset);

--- a/src/Cortex/Route/PriorityRouteCollection.php
+++ b/src/Cortex/Route/PriorityRouteCollection.php
@@ -71,6 +71,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->queue->current();
@@ -79,6 +80,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->queue->next();
@@ -87,6 +89,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->queue->key();
@@ -95,6 +98,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->queue->valid();
@@ -103,6 +107,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->queue->rewind();
@@ -111,6 +116,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->queue->count();

--- a/src/Cortex/Route/Route.php
+++ b/src/Cortex/Route/Route.php
@@ -83,6 +83,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->storage);
@@ -91,6 +92,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->storage[$offset] : null;
@@ -99,6 +101,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->storage[$offset] = $value;
@@ -107,6 +110,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if ($this->offsetExists($offset) && $offset !== 'id') {

--- a/src/Cortex/Router/RouteFilterIterator.php
+++ b/src/Cortex/Router/RouteFilterIterator.php
@@ -59,6 +59,7 @@ final class RouteFilterIterator extends \FilterIterator
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         /** @var RouteInterface $route */

--- a/src/Cortex/Router/Router.php
+++ b/src/Cortex/Router/Router.php
@@ -136,7 +136,7 @@ final class Router implements RouterInterface
             $parsed++;
             $id = $route->id();
             $this->parsedRoutes[$id] = $route;
-            $path = '/'.trim($route['path'], '/');
+            $path = '/'.trim((string)$route['path'], '/');
             // exact match
             if ($path === '/'.trim($uri->path(), '/')) {
                 $this->results = $this->finalizeRoute($route, [], $uri);
@@ -184,7 +184,7 @@ final class Router implements RouterInterface
     private function validateRoute(RouteInterface $route, $httpMethod)
     {
         $id = $route->id();
-        $path = trim($route['path'], '/');
+        $path = trim((string)$route['path'], '/');
         $handler = $route['handler'];
 
         return

--- a/src/Cortex/Uri/PsrUri.php
+++ b/src/Cortex/Uri/PsrUri.php
@@ -224,7 +224,7 @@ final class PsrUri implements PsrUriInterface
         $scheme = is_ssl() ? 'https' : 'http';
 
         $host = $this->marshallHostFromServer() ? : parse_url(home_url(), PHP_URL_HOST);
-        $host = trim($host, '/');
+        $host = trim((string)$host, '/');
 
         $pathArray = explode('?', $this->marshallPathFromServer(), 2);
         $path = trim($pathArray[0], '/');

--- a/src/Cortex/Uri/WordPressUri.php
+++ b/src/Cortex/Uri/WordPressUri.php
@@ -70,7 +70,7 @@ final class WordPressUri implements UriInterface
          * `example.com/subfolder` we need to strip down `/subfolder` from path and build a path
          * for route matching that is relative to home url.
          */
-        $homePath = trim(parse_url(home_url(), PHP_URL_PATH), '/');
+        $homePath = trim((string)parse_url(home_url(), PHP_URL_PATH), '/');
         $path = trim($this->uri->getPath(), '/');
         if ($homePath && strpos($path, $homePath) === 0) {
             $path = trim(substr($path, strlen($homePath)), '/');


### PR DESCRIPTION
This PR ensures compatibility with PHP 8.1.

- Add `#[\ReturnTypeWillChange]` attribute for all relevant methods of:
  - `\ArrayAccess`
  - `\Countable`
  - `\FilterIterator`
  - `\Iterator`
- Do not pass `null` to `trim`.
- Pin the `psr/http-message` dependency to a version below `1.1.0`, which is when return type declarations were added.