### PR TITLE
PHP 8.1 QA (Follow-Up)

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,0 +1,49 @@
+name: PHP Quality Assurance
+on:
+  push:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    strategy:
+      fail-fast: true
+      matrix:
+        php-versions: ['5.5', '5.6']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          coverage: none
+          tools: parallel-lint
+        env:
+          fail-fast: true
+
+      - name: Check syntax error in sources
+        run: parallel-lint ./src/ ./tests/
+
+      - name: Install dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Check cross-version PHP compatibility
+        if: ${{ matrix.php-versions == '5.6' }}
+        run: composer phpcompat
+
+      - name: Run unit tests
+        run: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
         "phpunit/phpunit": "4.8.*",
         "mockery/mockery": "0.9.3",
         "brain/monkey":    "~1.2.0",
-        "gmazzap/andrew":  "~1.0.0"
+        "gmazzap/andrew":  "~1.0.0",
+        "squizlabs/php_codesniffer": "^3.7",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpcompatibility/php-compatibility": "^9.3"
     },
     "autoload":          {
         "psr-4":    {
@@ -46,6 +49,14 @@
     },
     "minimum-stability": "stable",
     "config":            {
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "scripts" : {
+        "phpcompat": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -ps . --standard=PHPCompatibility --exclude=PHPCompatibility.Attributes.NewAttributes --ignore=*/vendor/* --extensions=php --runtime-set testVersion 7.0-"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require":           {
         "php":              ">=5.5",
         "nikic/fast-route": "~0.7.0",
-        "psr/http-message": "*"
+        "psr/http-message": "<1.1"
     },
     "require-dev":       {
         "phpunit/phpunit": "4.8.*",

--- a/src/Cortex/Group/Group.php
+++ b/src/Cortex/Group/Group.php
@@ -62,6 +62,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->route->offsetExists($offset);
@@ -70,6 +71,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->route->offsetGet($offset);
@@ -78,6 +80,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->route->offsetSet($offset, $value);
@@ -86,6 +89,7 @@ final class Group implements GroupInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->route->offsetUnset($offset);

--- a/src/Cortex/Route/DerivativeRouteTrait.php
+++ b/src/Cortex/Route/DerivativeRouteTrait.php
@@ -40,6 +40,7 @@ trait DerivativeRouteTrait
      * @param  string $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->route->offsetExists($offset);
@@ -50,6 +51,7 @@ trait DerivativeRouteTrait
      * @param  string $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->route->offsetGet($offset);
@@ -60,6 +62,7 @@ trait DerivativeRouteTrait
      * @param string $offset
      * @param mixed  $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->route->offsetSet($offset, $value);
@@ -69,6 +72,7 @@ trait DerivativeRouteTrait
      * @see RouteInterface::offsetUnset()
      * @param string $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->route->offsetUnset($offset);

--- a/src/Cortex/Route/PriorityRouteCollection.php
+++ b/src/Cortex/Route/PriorityRouteCollection.php
@@ -71,6 +71,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->queue->current();
@@ -79,6 +80,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->queue->next();
@@ -87,6 +89,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->queue->key();
@@ -95,6 +98,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->queue->valid();
@@ -103,6 +107,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->queue->rewind();
@@ -111,6 +116,7 @@ final class PriorityRouteCollection implements RouteCollectionInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->queue->count();

--- a/src/Cortex/Route/Route.php
+++ b/src/Cortex/Route/Route.php
@@ -83,6 +83,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->storage);
@@ -91,6 +92,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->storage[$offset] : null;
@@ -99,6 +101,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->storage[$offset] = $value;
@@ -107,6 +110,7 @@ final class Route implements RouteInterface
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if ($this->offsetExists($offset) && $offset !== 'id') {

--- a/src/Cortex/Router/RouteFilterIterator.php
+++ b/src/Cortex/Router/RouteFilterIterator.php
@@ -59,6 +59,7 @@ final class RouteFilterIterator extends \FilterIterator
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         /** @var RouteInterface $route */

--- a/src/Cortex/Router/Router.php
+++ b/src/Cortex/Router/Router.php
@@ -136,7 +136,7 @@ final class Router implements RouterInterface
             $parsed++;
             $id = $route->id();
             $this->parsedRoutes[$id] = $route;
-            $path = '/'.trim($route['path'], '/');
+            $path = '/'.trim((string)$route['path'], '/');
             // exact match
             if ($path === '/'.trim($uri->path(), '/')) {
                 $this->results = $this->finalizeRoute($route, [], $uri);
@@ -184,7 +184,7 @@ final class Router implements RouterInterface
     private function validateRoute(RouteInterface $route, $httpMethod)
     {
         $id = $route->id();
-        $path = trim($route['path'], '/');
+        $path = trim((string)$route['path'], '/');
         $handler = $route['handler'];
 
         return

--- a/src/Cortex/Uri/PsrUri.php
+++ b/src/Cortex/Uri/PsrUri.php
@@ -224,7 +224,7 @@ final class PsrUri implements PsrUriInterface
         $scheme = is_ssl() ? 'https' : 'http';
 
         $host = $this->marshallHostFromServer() ? : parse_url(home_url(), PHP_URL_HOST);
-        $host = trim($host, '/');
+        $host = trim((string)$host, '/');
 
         $pathArray = explode('?', $this->marshallPathFromServer(), 2);
         $path = trim($pathArray[0], '/');

--- a/src/Cortex/Uri/WordPressUri.php
+++ b/src/Cortex/Uri/WordPressUri.php
@@ -70,7 +70,7 @@ final class WordPressUri implements UriInterface
          * `example.com/subfolder` we need to strip down `/subfolder` from path and build a path
          * for route matching that is relative to home url.
          */
-        $homePath = trim(parse_url(home_url(), PHP_URL_PATH), '/');
+        $homePath = trim((string)parse_url(home_url(), PHP_URL_PATH), '/');
         $path = trim($this->uri->getPath(), '/');
         if ($homePath && strpos($path, $homePath) === 0) {
             $path = trim(substr($path, strlen($homePath)), '/');

--- a/tests/boot.php
+++ b/tests/boot.php
@@ -16,6 +16,5 @@ if (! realpath($vendor.'autoload.php')) {
 
 @require_once $vendor.'antecedent/patchwork/Patchwork.php';
 require_once $vendor.'autoload.php';
-require_once $vendor.'phpunit/phpunit/src/Framework/Assert/Functions.php';
 
 unset($vendor);

--- a/tests/src/Functional/CortexTest.php
+++ b/tests/src/Functional/CortexTest.php
@@ -33,8 +33,8 @@ class CortexTest extends TestCaseFunctional
         $boot1 = Cortex::boot();
         $boot2 = Cortex::boot();
 
-        assertTrue($boot1);
-        assertFalse($boot2);
+        static::assertTrue($boot1);
+        static::assertFalse($boot2);
     }
 
     /**
@@ -75,14 +75,14 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertTrue($do);
+        static::assertTrue($do);
     }
 
     public function testCortexBuildUriWithNoRequest()
     {
         $cortex = new Proxy(new Cortex());
 
-        assertInstanceOf(WordPressUri::class, $cortex->factoryUri());
+        static::assertInstanceOf(WordPressUri::class, $cortex->factoryUri());
     }
 
     public function testRouterReturnRouteResultsWhenGiven()
@@ -107,8 +107,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertTrue($do);
-        assertFalse(isset($wp->query_vars));
+        static::assertTrue($do);
+        static::assertFalse(isset($wp->query_vars));
     }
 
     public function testCortexMatchStaticRoute()
@@ -133,8 +133,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertSame(['post_type' => 'products'], $wp->query_vars);
-        assertFalse($do);
+        static::assertSame(['post_type' => 'products'], $wp->query_vars);
+        static::assertFalse($do);
     }
 
     public function testCortexMatchPagedRoute()
@@ -159,8 +159,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['paged' => 3], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['paged' => 3], $wp->query_vars);
     }
 
     public function testCortexAddPagedArgToMatchedPagedRoute()
@@ -173,7 +173,7 @@ class CortexTest extends TestCaseFunctional
                ->whenHappen(function (RouteCollectionInterface $routes) {
                    $routes->addRoute(new QueryRoute('/bar', function ($vars) {
 
-                       assertSame(3, $vars['paged']);
+                       static::assertSame(3, $vars['paged']);
 
                        return ['category' => 'bar'];
                    }, ['paged' => QueryRoute::PAGED_ARCHIVE]));
@@ -188,8 +188,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['category' => 'bar', 'paged' => 3], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['category' => 'bar', 'paged' => 3], $wp->query_vars);
     }
 
     public function testCortexNotMatchIfDifferentMethod()
@@ -214,7 +214,7 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertTrue($do);
+        static::assertTrue($do);
     }
 
     public function testCortexMatchStaticRouteWithUrlVars()
@@ -245,8 +245,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['post_type' => 'products', 'posts_per_page' => '12'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['post_type' => 'products', 'posts_per_page' => '12'], $wp->query_vars);
     }
 
     public function testDefaultQueryVarsAreMerged()
@@ -277,8 +277,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['posts_per_page' => 12, 'post_type' => 'products'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['posts_per_page' => 12, 'post_type' => 'products'], $wp->query_vars);
     }
 
     public function testDefaultQueryVarsAreOverwrittenByRouteVars()
@@ -309,8 +309,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['posts_per_page' => '24', 'post_type' => 'products'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['posts_per_page' => '24', 'post_type' => 'products'], $wp->query_vars);
     }
 
     public function testCortexMatchDynamicRouteWithUrlVars()
@@ -344,8 +344,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['post_type' => 'products', 'posts_per_page' => '12'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['post_type' => 'products', 'posts_per_page' => '12'], $wp->query_vars);
     }
 
     public function testCortexNotMatchDynamicRouteBadRequirements()
@@ -372,8 +372,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertTrue($do);
-        assertFalse(isset($wp->query_vars));
+        static::assertTrue($do);
+        static::assertFalse(isset($wp->query_vars));
     }
 
     public function testCortexMatchDynamicRouteOptionRequirements()
@@ -400,8 +400,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['greeting' => 'ciao'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['greeting' => 'ciao'], $wp->query_vars);
     }
 
     public function testCortexNotMatchDynamicRouteBadOptionRequirements()
@@ -428,8 +428,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertTrue($do);
-        assertFalse(isset($wp->query_vars));
+        static::assertTrue($do);
+        static::assertFalse(isset($wp->query_vars));
     }
 
     public function testCortexMatchFirstRoute()
@@ -461,8 +461,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['first' => 'bar', 'second' => 'baz'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['first' => 'bar', 'second' => 'baz'], $wp->query_vars);
     }
 
     public function testPreviewQueryArgsArePreserved()
@@ -492,8 +492,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(
+        static::assertFalse($do);
+        static::assertSame(
             [
                 'pagename'      => 'bar',
                 'preview'       => 'true',
@@ -532,8 +532,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['pagename' => 'bar'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['pagename' => 'bar'], $wp->query_vars);
     }
 
     public function testCortexNotMatchBecauseUrlChangedViaFilter()
@@ -569,8 +569,8 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertTrue($do);
-        assertFalse(isset($wp->query_vars));
+        static::assertTrue($do);
+        static::assertFalse(isset($wp->query_vars));
     }
 
     public function testCortexMatchWhenUrlChangedViaFilterIsInvalid()
@@ -599,7 +599,7 @@ class CortexTest extends TestCaseFunctional
 
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['post_type' => 'products'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['post_type' => 'products'], $wp->query_vars);
     }
 }

--- a/tests/src/Functional/RoutesTest.php
+++ b/tests/src/Functional/RoutesTest.php
@@ -94,12 +94,14 @@ class RoutesTest extends TestCaseFunctional
         $wp = \Mockery::mock('WP');
         $do = $cortex->doBoot($wp, true, $request);
 
-        assertFalse($do);
-        assertSame(['name' => 'baz'], $wp->query_vars);
+        static::assertFalse($do);
+        static::assertSame(['name' => 'baz'], $wp->query_vars);
     }
 
     public function testMatchRedirectRoute()
     {
+        Functions::when('home_url')->justReturn('http://example.com/');
+
         /** @var callable|null $factory */
         $factory = null;
 
@@ -123,6 +125,6 @@ class RoutesTest extends TestCaseFunctional
         $cortex = new Proxy(new Cortex());
         $do = $cortex->doBoot(\Mockery::mock('WP'), true, $request);
 
-        assertTrue($do);
+        static::assertTrue($do);
     }
 }

--- a/tests/src/Unit/Controller/QueryVarsControllerTest.php
+++ b/tests/src/Unit/Controller/QueryVarsControllerTest.php
@@ -27,7 +27,7 @@ class QueryVarsControllerTest extends TestCase
 
         $result = $controller->run(['foo' => 'bar'], $wp);
 
-        assertFalse($result);
-        assertSame(['foo' => 'bar'], $wp->query_vars);
+        static::assertFalse($result);
+        static::assertSame(['foo' => 'bar'], $wp->query_vars);
     }
 }

--- a/tests/src/Unit/Controller/RedirectControllerTest.php
+++ b/tests/src/Unit/Controller/RedirectControllerTest.php
@@ -31,7 +31,7 @@ class RedirectControllerTest extends TestCase
 
         $controller = new RedirectController();
 
-        assertTrue($controller->run(['redirect_to' => 'meh'], $wp));
+        static::assertTrue($controller->run(['redirect_to' => 'meh'], $wp));
     }
 
     public function testRunDefaultsToHomeUrlIfNoRedirectTo()
@@ -46,7 +46,7 @@ class RedirectControllerTest extends TestCase
 
         $controller = new RedirectController();
 
-        assertTrue($controller->run([], $wp));
+        static::assertTrue($controller->run([], $wp));
     }
 
     public function testRunAllStatusSettings()
@@ -66,6 +66,6 @@ class RedirectControllerTest extends TestCase
 
         $controller = new RedirectController();
 
-        assertTrue($controller->run($data, $wp));
+        static::assertTrue($controller->run($data, $wp));
     }
 }

--- a/tests/src/Unit/Group/GroupCollectionTest.php
+++ b/tests/src/Unit/Group/GroupCollectionTest.php
@@ -36,8 +36,8 @@ class GroupCollectionTest extends TestCase
         $proxy = new Proxy($collection);
 
         /** @noinspection PhpUndefinedFieldInspection */
-        assertSame($proxy->groups, ['foo' => $group]);
-        assertSame($return, $collection);
+        static::assertSame($proxy->groups, ['foo' => $group]);
+        static::assertSame($return, $collection);
     }
 
     public function testMergeGroup()
@@ -79,7 +79,7 @@ class GroupCollectionTest extends TestCase
         ksort($actual);
         ksort($expected);
 
-        assertSame($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testMergeMultipleGroups()
@@ -130,6 +130,6 @@ class GroupCollectionTest extends TestCase
         ksort($actual);
         ksort($expected);
 
-        assertSame($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 }

--- a/tests/src/Unit/Group/GroupTest.php
+++ b/tests/src/Unit/Group/GroupTest.php
@@ -24,14 +24,14 @@ class GroupTest extends TestCase
     {
         $group = new Group(['id' => 'test_me']);
 
-        assertSame('test_me', $group->id());
+        static::assertSame('test_me', $group->id());
     }
 
     public function testIdWhenDefault()
     {
         $group = new Group([]);
 
-        assertStringMatchesFormat('group_%s', $group->id());
+        static::assertStringMatchesFormat('group_%s', $group->id());
     }
 
     public function testToArrayStripsInvalid()
@@ -60,7 +60,7 @@ class GroupTest extends TestCase
         ksort($expected);
         ksort($actual);
 
-        assertSame($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testArrayAccess()
@@ -74,21 +74,21 @@ class GroupTest extends TestCase
             'priority' => 0,
         ]);
 
-        assertFalse($group->offsetExists('foo'));
-        assertTrue($group->offsetExists('id')); // id is auto generated
-        assertTrue($group->offsetExists('vars'));
-        assertSame('/', $group->offsetGet('path'));
-        assertSame(0, $group->offsetGet('priority'));
+        static::assertFalse($group->offsetExists('foo'));
+        static::assertTrue($group->offsetExists('id')); // id is auto generated
+        static::assertTrue($group->offsetExists('vars'));
+        static::assertSame('/', $group->offsetGet('path'));
+        static::assertSame(0, $group->offsetGet('priority'));
 
         unset($group['path']);
         $group['priority'] = 1;
         $group->offsetUnset('id');
         $group->offsetUnset('vars');
 
-        assertNull($group->offsetGet('path'));
-        assertSame(1, $group->offsetGet('priority'));
-        assertTrue($group->offsetExists('id')); // id cannot be unset
-        assertFalse($group->offsetExists('vars'));
-        assertSame('__return_true', $group['handler']);
+        static::assertNull($group->offsetGet('path'));
+        static::assertSame(1, $group->offsetGet('priority'));
+        static::assertTrue($group->offsetExists('id')); // id cannot be unset
+        static::assertFalse($group->offsetExists('vars'));
+        static::assertSame('__return_true', $group['handler']);
     }
 }

--- a/tests/src/Unit/Route/ActionRouteTest.php
+++ b/tests/src/Unit/Route/ActionRouteTest.php
@@ -34,21 +34,21 @@ class ActionRouteTest extends TestCase
             'priority' => 0
         ]);
 
-        assertFalse($route->offsetExists('foo'));
-        assertTrue($route->offsetExists('id')); // id is auto generated
-        assertSame(0, $route->offsetGet('priority'));
-        assertSame('foo/bar', $route->offsetGet('path'));
-        assertSame([], $route->offsetGet('vars'));
-        assertInternalType('callable', $route->offsetGet('handler'));
+        static::assertFalse($route->offsetExists('foo'));
+        static::assertTrue($route->offsetExists('id')); // id is auto generated
+        static::assertSame(0, $route->offsetGet('priority'));
+        static::assertSame('foo/bar', $route->offsetGet('path'));
+        static::assertSame([], $route->offsetGet('vars'));
+        static::assertInternalType('callable', $route->offsetGet('handler'));
 
         unset($route['path']);
         $route['priority'] = 1;
         $route->offsetUnset('id');
         $route->offsetUnset('vars');
 
-        assertNull($route->offsetGet('path'));
-        assertSame(1, $route->offsetGet('priority'));
-        assertTrue($route->offsetExists('id')); // id cannot be unset
-        assertFalse($route->offsetExists('vars'));
+        static::assertNull($route->offsetGet('path'));
+        static::assertSame(1, $route->offsetGet('priority'));
+        static::assertTrue($route->offsetExists('id')); // id cannot be unset
+        static::assertFalse($route->offsetExists('vars'));
     }
 }

--- a/tests/src/Unit/Route/PriorityRouteCollectionTest.php
+++ b/tests/src/Unit/Route/PriorityRouteCollectionTest.php
@@ -40,9 +40,9 @@ class PriorityRouteCollectionTest extends TestCase
 
         $proxy = new Proxy($collection);
 
-        assertSame(4, count($collection));
+        static::assertSame(4, count($collection));
         /** @noinspection PhpUndefinedFieldInspection */
-        assertSame([10, 11, 5, 9], $proxy->priorities);
+        static::assertSame([10, 11, 5, 9], $proxy->priorities);
 
         $actual = [];
         /** @var Route $route */
@@ -50,7 +50,7 @@ class PriorityRouteCollectionTest extends TestCase
             $actual[] = $route->id();
         }
 
-        assertSame(['r_3', 'r_4', 'r_1', 'r_2'], $actual);
+        static::assertSame(['r_3', 'r_4', 'r_1', 'r_2'], $actual);
     }
 
     public function testPagedNotAddedIfNoPath()
@@ -61,9 +61,9 @@ class PriorityRouteCollectionTest extends TestCase
         $collection->addRoute($route);
         $proxy = new Proxy($collection);
 
-        assertSame(1, count($collection));
+        static::assertSame(1, count($collection));
         /** @noinspection PhpUndefinedFieldInspection */
-        assertSame([10], $proxy->priorities);
+        static::assertSame([10], $proxy->priorities);
     }
 
     public function testPagedSingle()
@@ -78,17 +78,17 @@ class PriorityRouteCollectionTest extends TestCase
         $collection->addRoute($route);
         $proxy = new Proxy($collection);
 
-        assertSame(2, count($collection));
+        static::assertSame(2, count($collection));
         /** @noinspection PhpUndefinedFieldInspection */
-        assertSame([10, 11], $proxy->priorities);
+        static::assertSame([10, 11], $proxy->priorities);
 
         /** @var Route $route */
         $i = 0;
         foreach ($collection as $route) {
             $id = $i === 0 ? 'route_example_paged' : 'route_example';
             $path = $i === 0 ? '/foo/{page:\d+}' : '/foo';
-            assertSame($id, $route->id());
-            assertSame($path, $route['path']);
+            static::assertSame($id, $route->id());
+            static::assertSame($path, $route['path']);
             $i++;
         }
     }
@@ -106,17 +106,17 @@ class PriorityRouteCollectionTest extends TestCase
         $collection->addRoute($route);
         $proxy = new Proxy($collection);
 
-        assertSame(2, count($collection));
+        static::assertSame(2, count($collection));
         /** @noinspection PhpUndefinedFieldInspection */
-        assertSame([32, 33], $proxy->priorities);
+        static::assertSame([32, 33], $proxy->priorities);
 
         /** @var Route $route */
         $i = 0;
         foreach ($collection as $route) {
             $id = $i === 0 ? 'route_example_paged' : 'route_example';
             $path = $i === 0 ? '/bar/page/{paged:\d+}' : '/bar';
-            assertSame($id, $route->id());
-            assertSame($path, $route['path']);
+            static::assertSame($id, $route->id());
+            static::assertSame($path, $route['path']);
             $i++;
         }
     }

--- a/tests/src/Unit/Route/QueryRouteTest.php
+++ b/tests/src/Unit/Route/QueryRouteTest.php
@@ -36,22 +36,22 @@ class QueryRouteTest extends TestCase
             'priority' => 0
         ]);
 
-        assertFalse($route->offsetExists('foo'));
-        assertTrue($route->offsetExists('id')); // id is auto generated
-        assertSame(0, $route->offsetGet('priority'));
-        assertSame('foo/bar', $route->offsetGet('path'));
-        assertSame($vars, $route->offsetGet('vars'));
-        assertInstanceOf(QueryVarsController::class, $route->offsetGet('handler'));
+        static::assertFalse($route->offsetExists('foo'));
+        static::assertTrue($route->offsetExists('id')); // id is auto generated
+        static::assertSame(0, $route->offsetGet('priority'));
+        static::assertSame('foo/bar', $route->offsetGet('path'));
+        static::assertSame($vars, $route->offsetGet('vars'));
+        static::assertInstanceOf(QueryVarsController::class, $route->offsetGet('handler'));
 
         unset($route['path']);
         $route['priority'] = 1;
         $route->offsetUnset('id');
         $route->offsetUnset('vars');
 
-        assertNull($route->offsetGet('path'));
-        assertSame(1, $route->offsetGet('priority'));
-        assertTrue($route->offsetExists('id')); // id cannot be unset
-        assertFalse($route->offsetExists('vars'));
+        static::assertNull($route->offsetGet('path'));
+        static::assertSame(1, $route->offsetGet('priority'));
+        static::assertTrue($route->offsetExists('id')); // id cannot be unset
+        static::assertFalse($route->offsetExists('vars'));
     }
 
     public function testToArray()
@@ -65,17 +65,17 @@ class QueryRouteTest extends TestCase
 
         $array = $route->toArray();
 
-        assertTrue(array_key_exists('id', $array));
-        assertTrue(array_key_exists('handler', $array));
-        assertTrue(array_key_exists('vars', $array));
-        assertTrue(array_key_exists('priority', $array));
-        assertFalse(array_key_exists('foo', $array));
-        assertFalse(array_key_exists(0, $array));
-        assertFalse(array_key_exists(1, $array));
-        assertTrue(array_key_exists('meh', $array));
-        assertSame('foo/bar', $array['path']);
-        assertSame(['foo' => 'bar'], $array['vars']);
-        assertInstanceOf(QueryVarsController::class, $array['handler']);
+        static::assertTrue(array_key_exists('id', $array));
+        static::assertTrue(array_key_exists('handler', $array));
+        static::assertTrue(array_key_exists('vars', $array));
+        static::assertTrue(array_key_exists('priority', $array));
+        static::assertFalse(array_key_exists('foo', $array));
+        static::assertFalse(array_key_exists(0, $array));
+        static::assertFalse(array_key_exists(1, $array));
+        static::assertTrue(array_key_exists('meh', $array));
+        static::assertSame('foo/bar', $array['path']);
+        static::assertSame(['foo' => 'bar'], $array['vars']);
+        static::assertInstanceOf(QueryVarsController::class, $array['handler']);
     }
 
     public function testId()
@@ -83,7 +83,7 @@ class QueryRouteTest extends TestCase
         $route1 = new QueryRoute('foo/bar', []);
         $route2 = new QueryRoute('foo/bar', [], ['id' => 'route_2']);
 
-        assertStringMatchesFormat('route_%s', $route1->id());
-        assertSame('route_2', $route2->id());
+        static::assertStringMatchesFormat('route_%s', $route1->id());
+        static::assertSame('route_2', $route2->id());
     }
 }

--- a/tests/src/Unit/Route/RedirectRouteTest.php
+++ b/tests/src/Unit/Route/RedirectRouteTest.php
@@ -35,9 +35,9 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => 'http://example.com/meh',
         ];
 
-        assertSame('/path/from', $route['path']);
-        assertSame($expectedVars, $route['vars']);
-        assertSame(2, $route['priority']);
+        static::assertSame('/path/from', $route['path']);
+        static::assertSame($expectedVars, $route['vars']);
+        static::assertSame(2, $route['priority']);
     }
 
     public function testRedirectToInternalFromAbsoluteString()
@@ -50,8 +50,8 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => 'https://foo.bar/',
         ];
 
-        assertSame('/path/from', $route['path']);
-        assertSame($expectedVars, $route['vars']);
+        static::assertSame('/path/from', $route['path']);
+        static::assertSame($expectedVars, $route['vars']);
     }
 
     public function testRedirectToNullIfBadStringExternal()
@@ -68,8 +68,8 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => '',
         ];
 
-        assertSame('/from', $route['path']);
-        assertSame($expectedVars, $route['vars']);
+        static::assertSame('/from', $route['path']);
+        static::assertSame($expectedVars, $route['vars']);
     }
 
     public function testRedirectToExternalFromString()
@@ -82,8 +82,8 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => 'https://foo.bar/',
         ];
 
-        assertSame('/path/from', $route['path']);
-        assertSame($expectedVars, $route['vars']);
+        static::assertSame('/path/from', $route['path']);
+        static::assertSame($expectedVars, $route['vars']);
     }
 
     public function testAutoAbsoluteRedirectToFromCallback()
@@ -106,10 +106,10 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => 'http://example.com/bar',
         ];
 
-        assertSame('/path/from', $route['path']);
-        assertSame(2, $route['priority']);
-        assertInstanceOf('Closure', $route['vars']);
-        assertSame($expectedVars, $route['vars'](['foo' => 'bar']));
+        static::assertSame('/path/from', $route['path']);
+        static::assertSame(2, $route['priority']);
+        static::assertInstanceOf('Closure', $route['vars']);
+        static::assertSame($expectedVars, $route['vars'](['foo' => 'bar']));
     }
 
     public function testRedirectToInternalEmptyIfCallbackReturnNoString()
@@ -127,8 +127,8 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => '',
         ];
 
-        assertInstanceOf('Closure', $route['vars']);
-        assertSame($expectedVars, $route['vars'](['bar' => 111]));
+        static::assertInstanceOf('Closure', $route['vars']);
+        static::assertSame($expectedVars, $route['vars'](['bar' => 111]));
     }
 
     public function testRedirectToInternalEmptyString()
@@ -141,7 +141,7 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => '',
         ];
 
-        assertSame($expectedVars, $route['vars']);
+        static::assertSame($expectedVars, $route['vars']);
     }
 
     public function testAbsoluteRedirectToFromCallback()
@@ -160,10 +160,10 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => 'http://example.com/bar',
         ];
 
-        assertSame('/path/from', $route['path']);
-        assertSame(2, $route['priority']);
-        assertInstanceOf('Closure', $route['vars']);
-        assertSame($expectedVars, $route['vars'](['foo' => 'bar']));
+        static::assertSame('/path/from', $route['path']);
+        static::assertSame(2, $route['priority']);
+        static::assertInstanceOf('Closure', $route['vars']);
+        static::assertSame($expectedVars, $route['vars'](['foo' => 'bar']));
     }
 
     public function testRedirectToExternalFromCallback()
@@ -182,9 +182,9 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => 'https://www.bar.it/',
         ];
 
-        assertSame('/path/from', $route['path']);
-        assertInstanceOf('Closure', $route['vars']);
-        assertSame($expectedVars, $route['vars'](['sub' => 'www']));
+        static::assertSame('/path/from', $route['path']);
+        static::assertInstanceOf('Closure', $route['vars']);
+        static::assertSame($expectedVars, $route['vars'](['sub' => 'www']));
     }
 
     public function testRedirectToExternalEmptyIfCallbackReturnNoUrl()
@@ -203,9 +203,9 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => '',
         ];
 
-        assertSame('/path/from', $route['path']);
-        assertInstanceOf('Closure', $route['vars']);
-        assertSame($expectedVars, $route['vars'](['sub' => 'www']));
+        static::assertSame('/path/from', $route['path']);
+        static::assertInstanceOf('Closure', $route['vars']);
+        static::assertSame($expectedVars, $route['vars'](['sub' => 'www']));
     }
 
     public function testStatusTo301IfBad()
@@ -218,6 +218,6 @@ class RedirectRouteTest extends TestCase
             'redirect_to'       => 'http://example.com',
         ];
 
-        assertSame($expectedVars, $route['vars']);
+        static::assertSame($expectedVars, $route['vars']);
     }
 }

--- a/tests/src/Unit/Route/RouteTest.php
+++ b/tests/src/Unit/Route/RouteTest.php
@@ -36,23 +36,23 @@ class RouteTest extends TestCase
             'priority' => 0,
         ]);
 
-        assertFalse($route->offsetExists('foo'));
-        assertSame('meh', $route->offsetGet('meh'));
-        assertTrue($route->offsetExists('id')); // id is auto generated
-        assertSame(0, $route->offsetGet('priority'));
-        assertSame('/', $route->offsetGet('path'));
-        assertSame($vars, $route->offsetGet('vars'));
-        assertSame('__return_true', $route->offsetGet('handler'));
+        static::assertFalse($route->offsetExists('foo'));
+        static::assertSame('meh', $route->offsetGet('meh'));
+        static::assertTrue($route->offsetExists('id')); // id is auto generated
+        static::assertSame(0, $route->offsetGet('priority'));
+        static::assertSame('/', $route->offsetGet('path'));
+        static::assertSame($vars, $route->offsetGet('vars'));
+        static::assertSame('__return_true', $route->offsetGet('handler'));
 
         unset($route['path']);
         $route['priority'] = 1;
         $route->offsetUnset('id');
         $route->offsetUnset('vars');
 
-        assertNull($route->offsetGet('path'));
-        assertSame(1, $route->offsetGet('priority'));
-        assertTrue($route->offsetExists('id')); // id cannot be unset
-        assertFalse($route->offsetExists('vars'));
+        static::assertNull($route->offsetGet('path'));
+        static::assertSame(1, $route->offsetGet('priority'));
+        static::assertTrue($route->offsetExists('id')); // id cannot be unset
+        static::assertFalse($route->offsetExists('vars'));
     }
 
     public function testToArray()
@@ -68,17 +68,17 @@ class RouteTest extends TestCase
 
         $array = $route->toArray();
 
-        assertTrue(array_key_exists('id', $array));
-        assertTrue(array_key_exists('vars', $array));
-        assertTrue(array_key_exists('priority', $array));
-        assertFalse(array_key_exists('handler', $array));
-        assertFalse(array_key_exists('foo', $array));
-        assertFalse(array_key_exists(0, $array));
-        assertFalse(array_key_exists(1, $array));
-        assertSame(['foo' => 'bar'], $array['meh']);
-        assertSame('foo/bar', $array['path']);
-        assertSame(['foo' => 'bar'], $array['vars']);
-        assertStringMatchesFormat('route_%s', $array['id']);
+        static::assertTrue(array_key_exists('id', $array));
+        static::assertTrue(array_key_exists('vars', $array));
+        static::assertTrue(array_key_exists('priority', $array));
+        static::assertFalse(array_key_exists('handler', $array));
+        static::assertFalse(array_key_exists('foo', $array));
+        static::assertFalse(array_key_exists(0, $array));
+        static::assertFalse(array_key_exists(1, $array));
+        static::assertSame(['foo' => 'bar'], $array['meh']);
+        static::assertSame('foo/bar', $array['path']);
+        static::assertSame(['foo' => 'bar'], $array['vars']);
+        static::assertStringMatchesFormat('route_%s', $array['id']);
     }
 
     public function testId()
@@ -86,7 +86,7 @@ class RouteTest extends TestCase
         $route1 = new Route([]);
         $route2 = new Route(['id' => 'route_2']);
 
-        assertStringMatchesFormat('route_%s', $route1->id());
-        assertSame('route_2', $route2->id());
+        static::assertStringMatchesFormat('route_%s', $route1->id());
+        static::assertSame('route_2', $route2->id());
     }
 }

--- a/tests/src/Unit/Router/ResultHandlerTest.php
+++ b/tests/src/Unit/Router/ResultHandlerTest.php
@@ -36,8 +36,8 @@ class ResultHandlerTest extends TestCase
 
         $handler = new ResultHandler();
 
-        assertTrue($handler->handle($result, $wp, true));
-        assertFalse($handler->handle($result, $wp, false));
+        static::assertTrue($handler->handle($result, $wp, true));
+        static::assertFalse($handler->handle($result, $wp, false));
     }
 
     public function testHandleAllCallbacks()
@@ -85,8 +85,8 @@ class ResultHandlerTest extends TestCase
 
         $handler = new ResultHandler();
 
-        assertFalse($handler->handle($result, $wp, true));
-        assertSame($expected, $accumulator);
+        static::assertFalse($handler->handle($result, $wp, true));
+        static::assertSame($expected, $accumulator);
     }
 
     public function testHandleTemplate()
@@ -136,7 +136,7 @@ class ResultHandlerTest extends TestCase
 
         $wp = \Mockery::mock('WP');
 
-        assertTrue($handler->handle($result, $wp, true));
+        static::assertTrue($handler->handle($result, $wp, true));
     }
 
     public function testHandleTemplateDoNothingIfNoTemplateFound()
@@ -186,6 +186,6 @@ class ResultHandlerTest extends TestCase
 
         $wp = \Mockery::mock('WP');
 
-        assertTrue($handler->handle($result, $wp, true));
+        static::assertTrue($handler->handle($result, $wp, true));
     }
 }

--- a/tests/src/Unit/Router/RouteFilterIteratorTest.php
+++ b/tests/src/Unit/Router/RouteFilterIteratorTest.php
@@ -45,7 +45,7 @@ class RouteFilterIteratorTest extends TestCase
             $ok[] = $route->id();
         }
 
-        assertSame(['r1', 'r3'], $ok);
+        static::assertSame(['r1', 'r3'], $ok);
     }
 
     public function testAcceptForHost()
@@ -70,7 +70,7 @@ class RouteFilterIteratorTest extends TestCase
             $ok[] = $route->id();
         }
 
-        assertSame(['r1', 'r3'], $ok);
+        static::assertSame(['r1', 'r3'], $ok);
     }
 
     public function testAcceptForHostWildcard()
@@ -95,6 +95,6 @@ class RouteFilterIteratorTest extends TestCase
             $ok[] = $route->id();
         }
 
-        assertSame(['r1', 'r2', 'r3'], $ok);
+        static::assertSame(['r1', 'r2', 'r3'], $ok);
     }
 }

--- a/tests/src/Unit/Router/RouterTest.php
+++ b/tests/src/Unit/Router/RouterTest.php
@@ -44,7 +44,7 @@ class RouterTest extends TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $proxy->results = $result;
 
-        assertSame($result, $router->match($uri, 'GET'));
+        static::assertSame($result, $router->match($uri, 'GET'));
     }
 
     public function testMatchNothingIfNoRoutes()
@@ -71,8 +71,8 @@ class RouterTest extends TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $data = $proxy->data;
 
-        assertFalse($result->matched());
-        assertSame($expected, $data);
+        static::assertFalse($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchNothingIfNoFilteredRoutes()
@@ -104,8 +104,8 @@ class RouterTest extends TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $data = $proxy->data;
 
-        assertFalse($result->matched());
-        assertSame($expected, $data);
+        static::assertFalse($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchNothingIfNoValidatingRoutes()
@@ -141,8 +141,8 @@ class RouterTest extends TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $data = $proxy->data;
 
-        assertFalse($result->matched());
-        assertSame($expected, $data);
+        static::assertFalse($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchNotMatching()
@@ -176,7 +176,7 @@ class RouterTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->with('POST', '/bar')->andReturn([0]);
 
         $factory = function (array $args) use ($dispatcher) {
-            assertSame($args, ['foo' => 'bar']);
+            static::assertSame($args, ['foo' => 'bar']);
 
             return $dispatcher;
         };
@@ -199,8 +199,8 @@ class RouterTest extends TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $data = $proxy->data;
 
-        assertFalse($result->matched());
-        assertSame($expected, $data);
+        static::assertFalse($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchMatchingExactMatch()
@@ -237,7 +237,7 @@ class RouterTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->never();
 
         $factory = function (array $args) use ($dispatcher) {
-            assertSame($args, ['foo' => 'bar']);
+            static::assertSame($args, ['foo' => 'bar']);
 
             return $dispatcher;
         };
@@ -263,8 +263,8 @@ class RouterTest extends TestCase
         ksort($expected);
         ksort($data);
 
-        assertTrue($result->matched());
-        assertSame($expected, $data);
+        static::assertTrue($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchDynamicMatch()
@@ -309,7 +309,7 @@ class RouterTest extends TestCase
                    ]);
 
         $factory = function (array $args) use ($dispatcher) {
-            assertSame($args, ['foo' => 'bar']);
+            static::assertSame($args, ['foo' => 'bar']);
 
             return $dispatcher;
         };
@@ -335,8 +335,8 @@ class RouterTest extends TestCase
         ksort($expected);
         ksort($data);
 
-        assertTrue($result->matched());
-        assertSame($expected, $data);
+        static::assertTrue($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchMatchingExactMatchNoQueryVars()
@@ -374,7 +374,7 @@ class RouterTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->never();
 
         $factory = function (array $args) use ($dispatcher) {
-            assertSame($args, ['foo' => 'bar']);
+            static::assertSame($args, ['foo' => 'bar']);
 
             return $dispatcher;
         };
@@ -397,8 +397,8 @@ class RouterTest extends TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $data = $proxy->data;
 
-        assertTrue($result->matched());
-        assertSame($expected, $data);
+        static::assertTrue($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchMatchingNoQueryVarsMaintainPreviewVar()
@@ -443,7 +443,7 @@ class RouterTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->never();
 
         $factory = function (array $args) use ($dispatcher) {
-            assertSame($args, ['foo' => 'bar']);
+            static::assertSame($args, ['foo' => 'bar']);
 
             return $dispatcher;
         };
@@ -474,8 +474,8 @@ class RouterTest extends TestCase
         ksort($data);
         ksort($expected);
 
-        assertTrue($result->matched());
-        assertSame($expected, $data);
+        static::assertTrue($result->matched());
+        static::assertSame($expected, $data);
     }
 
     public function testMatchMatchingExactMatchCallableVars()
@@ -514,7 +514,7 @@ class RouterTest extends TestCase
         $dispatcher->shouldReceive('dispatch')->never();
 
         $factory = function (array $args) use ($dispatcher) {
-            assertSame($args, ['foo' => 'bar']);
+            static::assertSame($args, ['foo' => 'bar']);
 
             return $dispatcher;
         };
@@ -537,7 +537,7 @@ class RouterTest extends TestCase
         /** @noinspection PhpUndefinedFieldInspection */
         $data = $proxy->data;
 
-        assertTrue($result->matched());
-        assertSame($expected, $data);
+        static::assertTrue($result->matched());
+        static::assertSame($expected, $data);
     }
 }

--- a/tests/src/Unit/Uri/PsrUriTest.php
+++ b/tests/src/Unit/Uri/PsrUriTest.php
@@ -27,7 +27,7 @@ class PsrUriTest extends TestCase
 
         $uri = new PsrUri(['HTTP_HOST' => 'example.com']);
 
-        assertSame('https', $uri->getScheme());
+        static::assertSame('https', $uri->getScheme());
     }
 
     public function testGetSchemeNoSsl()
@@ -36,72 +36,101 @@ class PsrUriTest extends TestCase
 
         $uri = new PsrUri(['HTTP_HOST' => 'example.com']);
 
-        assertSame('http', $uri->getScheme());
+        static::assertSame('http', $uri->getScheme());
     }
 
     public function testGetHostFromHttpHost()
     {
+        Functions::when('is_ssl')->justReturn(false);
+
         $uri = new PsrUri(['HTTP_HOST' => 'example.com']);
 
-        assertSame('example.com', $uri->getHost());
+        static::assertSame('example.com', $uri->getHost());
     }
 
     public function testGetHostFromHttpServerName()
     {
+        Functions::when('is_ssl')->justReturn(false);
+
         $uri = new PsrUri(['SERVER_NAME' => 'example.it']);
 
-        assertSame('example.it', $uri->getHost());
+        static::assertSame('example.it', $uri->getHost());
     }
 
     public function testGetHostFromHomeUrl()
     {
+        Functions::when('is_ssl')->justReturn(false);
         Functions::when('home_url')->justReturn('http://www.example.co.uk/wp/');
 
         $uri = new PsrUri(['meh' => 'meh']);
 
-        assertSame('www.example.co.uk', $uri->getHost());
+        static::assertSame('www.example.co.uk', $uri->getHost());
     }
 
     public function testGetHostStripPort()
     {
+        Functions::when('is_ssl')->justReturn(false);
+
         $uri = new PsrUri(['HTTP_HOST' => 'example.com:8080']);
 
-        assertSame('example.com', $uri->getHost());
+        static::assertSame('example.com', $uri->getHost());
     }
 
     public function testGetPath()
     {
-        $uri = new PsrUri(['REQUEST_URI' => '/foo/bar/']);
+        Functions::when('is_ssl')->justReturn(false);
 
-        assertSame('foo/bar', $uri->getPath());
+        $uri = new PsrUri([
+            'HTTP_HOST'   => 'example.com',
+            'REQUEST_URI' => '/foo/bar/',
+        ]);
+
+        static::assertSame('foo/bar', $uri->getPath());
     }
 
     public function testGetPathStripHost()
     {
-        $uri = new PsrUri(['REQUEST_URI' => 'http://example.com/foo/bar/']);
+        Functions::when('is_ssl')->justReturn(false);
 
-        assertSame('foo/bar', $uri->getPath());
+        $uri = new PsrUri([
+            'HTTP_HOST'   => 'example.com',
+            'REQUEST_URI' => 'http://example.com/foo/bar/',
+        ]);
+
+        static::assertSame('foo/bar', $uri->getPath());
     }
 
     public function testGetQuery()
     {
-        $uri = new PsrUri(['QUERY_STRING' => 'foo=bar']);
+        Functions::when('is_ssl')->justReturn(false);
 
-        assertSame('foo=bar', $uri->getQuery());
+        $uri = new PsrUri([
+            'HTTP_HOST'    => 'example.com',
+            'QUERY_STRING' => 'foo=bar',
+        ]);
+
+        static::assertSame('foo=bar', $uri->getQuery());
     }
 
     public function testGetQueryStripQuestion()
     {
-        $uri = new PsrUri(['QUERY_STRING' => '?foo=bar']);
+        Functions::when('is_ssl')->justReturn(false);
 
-        assertSame('foo=bar', $uri->getQuery());
+        $uri = new PsrUri([
+            'HTTP_HOST'    => 'example.com',
+            'QUERY_STRING' => '?foo=bar',
+        ]);
+
+        static::assertSame('foo=bar', $uri->getQuery());
     }
 
     public function testGetQueryEmpty()
     {
+        Functions::when('is_ssl')->justReturn(false);
+
         $uri = new PsrUri(['HTTP_HOST' => 'example.com']);
 
-        assertSame('', $uri->getQuery());
+        static::assertSame('', $uri->getQuery());
     }
 
     public function testToString()
@@ -114,7 +143,7 @@ class PsrUriTest extends TestCase
             'QUERY_STRING' => '?foo=bar',
         ]);
 
-        assertSame('https:://example.com/foo/bar?foo=bar', (string) $uri);
+        static::assertSame('https:://example.com/foo/bar?foo=bar', (string) $uri);
     }
 
     /**

--- a/tests/src/Unit/Uri/WordPressUriTest.php
+++ b/tests/src/Unit/Uri/WordPressUriTest.php
@@ -42,11 +42,11 @@ class WordPressUriTest extends TestCase
         $uri = $this->psrUriFromUrl('https://www.example.com/foo/bar.php?meh=1');
         $wpUri = new WordPressUri($uri);
 
-        assertSame('https', $wpUri->scheme());
-        assertSame('www.example.com', $wpUri->host());
-        assertSame('foo/bar.php', $wpUri->path());
-        assertSame(['foo', 'bar.php'], $wpUri->chunks());
-        assertSame(['meh' => '1'], $wpUri->vars());
+        static::assertSame('https', $wpUri->scheme());
+        static::assertSame('www.example.com', $wpUri->host());
+        static::assertSame('foo/bar.php', $wpUri->path());
+        static::assertSame(['foo', 'bar.php'], $wpUri->chunks());
+        static::assertSame(['meh' => '1'], $wpUri->vars());
     }
 
     public function testNoQueryVars()
@@ -56,11 +56,11 @@ class WordPressUriTest extends TestCase
         $uri = $this->psrUriFromUrl('https://www.example.com/foo/bar/');
         $wpUri = new WordPressUri($uri);
 
-        assertSame('https', $wpUri->scheme());
-        assertSame('www.example.com', $wpUri->host());
-        assertSame('foo/bar', $wpUri->path());
-        assertSame(['foo', 'bar'], $wpUri->chunks());
-        assertSame([], $wpUri->vars());
+        static::assertSame('https', $wpUri->scheme());
+        static::assertSame('www.example.com', $wpUri->host());
+        static::assertSame('foo/bar', $wpUri->path());
+        static::assertSame(['foo', 'bar'], $wpUri->chunks());
+        static::assertSame([], $wpUri->vars());
     }
 
     public function testHomeUrlHomePath()
@@ -70,11 +70,11 @@ class WordPressUriTest extends TestCase
         $uri = $this->psrUriFromUrl('https://www.example.com/foo/');
         $wpUri = new WordPressUri($uri);
 
-        assertSame('https', $wpUri->scheme());
-        assertSame('www.example.com', $wpUri->host());
-        assertSame('/', $wpUri->path());
-        assertSame([], $wpUri->chunks());
-        assertSame([], $wpUri->vars());
+        static::assertSame('https', $wpUri->scheme());
+        static::assertSame('www.example.com', $wpUri->host());
+        static::assertSame('/', $wpUri->path());
+        static::assertSame([], $wpUri->chunks());
+        static::assertSame([], $wpUri->vars());
     }
 
     public function testHomeUrlNoHomePath()
@@ -84,10 +84,10 @@ class WordPressUriTest extends TestCase
         $uri = $this->psrUriFromUrl('https://www.example.com/');
         $wpUri = new WordPressUri($uri);
 
-        assertSame('https', $wpUri->scheme());
-        assertSame('www.example.com', $wpUri->host());
-        assertSame('/', $wpUri->path());
-        assertSame([], $wpUri->chunks());
-        assertSame([], $wpUri->vars());
+        static::assertSame('https', $wpUri->scheme());
+        static::assertSame('www.example.com', $wpUri->host());
+        static::assertSame('/', $wpUri->path());
+        static::assertSame([], $wpUri->chunks());
+        static::assertSame([], $wpUri->vars());
     }
 }


### PR DESCRIPTION
This PR is a follow-up to #40 that updates the tests to use `static::assert*` instead of global namespace functions.

Some tests were also missing a mock (e.g., `is_ssl` or `home_url`), or setting up the `HTTP_HOST` server value.

The PR also adds a basic GitHub Action workflow for running tests and PHP compatibility checks (see [here](https://github.com/tfrommen/Cortex/actions/runs/6089118957)).

Feel free to discard this PR, in case you don't want to update all the tests etc., or if you want to do it differently.